### PR TITLE
스크롤 페이지 요청 오류 해결

### DIFF
--- a/like-knu/src/pages/InfiniteScrollNoticePage.jsx
+++ b/like-knu/src/pages/InfiniteScrollNoticePage.jsx
@@ -63,14 +63,12 @@ export default function InfiniteScrollNoticePage() {
       <PageContainer>
         {
           notices.map((notice, index) => (
-            <Content key={index} onClick={() => window.open(notice.announcementUrl, "_blank")}>
-              <Detail>
-                <div>{notice.announcementTag}</div>
-                <div>{notice.announcementDate}</div>
-              </Detail>
-
-              <Title>{notice.announcementTitle}</Title>
-            </Content>
+            <ListItem
+              head={notice.announcementTag}
+              subHead={notice.announcementDate}
+              body={notice.announcementTitle}
+              url={notice.announcementUrl}
+            ></ListItem>
           ))
         }
         <InfiniteScroll

--- a/like-knu/src/pages/InfiniteScrollNoticePage.jsx
+++ b/like-knu/src/pages/InfiniteScrollNoticePage.jsx
@@ -10,7 +10,7 @@ import styled from "styled-components";
 import colors from "../constants/colors";
 import {getCampus} from "../utils/DeviceManageUtil";
 import Campus from "../constants/campus";
-import async from "async";
+import ListItem from "../components/ListItem";
 
 export default function InfiniteScrollNoticePage() {
 

--- a/like-knu/src/pages/InfiniteScrollNoticePage.jsx
+++ b/like-knu/src/pages/InfiniteScrollNoticePage.jsx
@@ -25,12 +25,18 @@ export default function InfiniteScrollNoticePage() {
   campus = keys.find((key) => Campus[key] === campus);
 
   const getNotices = async (category) => {
-    const res = await notice(campus, category, currentPage);
+    const res = await notice(campus, category);
     setNotices(res.body);
     setTotalPages(res.page.totalPages);
   }
 
   const fetchData = async () => {
+    if (notices.length === 0) {
+      const res = await notice(campus, apiNoticeTabList[category], 1);
+      setNotices(notices.concat(res.body));
+      return;
+    }
+
     if (totalPages === currentPage) {
       setHasMore(false);
     }
@@ -42,7 +48,7 @@ export default function InfiniteScrollNoticePage() {
 
   useEffect(() => {
     setNotices([]);
-    setCurrentPage(1);
+    setCurrentPage(2);
     setHasMore(true);
     getNotices(apiNoticeTabList[category]);
   }, [category]);

--- a/like-knu/src/pages/InfiniteScrollNoticePage.jsx
+++ b/like-knu/src/pages/InfiniteScrollNoticePage.jsx
@@ -82,6 +82,7 @@ export default function InfiniteScrollNoticePage() {
           loader={ // 로딩 메시지
             <div>불러오는 중..</div>
           }
+          scrollThreshold={0.9}
         />
       </PageContainer>
     </PageLayout>

--- a/like-knu/src/pages/InfiniteScrollNoticePage.jsx
+++ b/like-knu/src/pages/InfiniteScrollNoticePage.jsx
@@ -6,8 +6,6 @@ import {apiNoticeTabList, noticeTab} from "../constants/tabName";
 import {useEffect, useState} from "react";
 import {notice} from "../api/notice";
 import InfiniteScroll from 'react-infinite-scroll-component';
-import styled from "styled-components";
-import colors from "../constants/colors";
 import {getCampus} from "../utils/DeviceManageUtil";
 import Campus from "../constants/campus";
 import ListItem from "../components/ListItem";
@@ -89,23 +87,3 @@ export default function InfiniteScrollNoticePage() {
     </PageLayout>
   )
 }
-
-const Content = styled.a`
-  white-space: nowrap;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  margin-bottom: 24px;
-`
-const Detail = styled.div`
-  color: ${colors.gray350};
-  display: flex;
-  flex-direction: row;
-  justify-content: space-between;
-  font-size: 1.1rem;
-  margin-bottom: 4px;
-`
-
-const Title = styled.span`
-  font-size: 1.3rem;
-  color: ${colors.black};
-`

--- a/like-knu/src/pages/NotificationPage.jsx
+++ b/like-knu/src/pages/NotificationPage.jsx
@@ -1,5 +1,5 @@
 import PageLayout from "../layouts/PageLayout";
-import {Header, PageHeader} from "../components/styles/PageHeader";
+import {Header} from "../components/styles/PageHeader";
 import PageContainer from "../layouts/PageContainer";
 import ListItem from "../components/ListItem";
 import {useEffect, useState} from "react";
@@ -15,20 +15,14 @@ export default function NotificationPage() {
   const [currentPage, setCurrentPage] = useState(1);
   const [hasMore, setHasMore] = useState(true);
 
-  const updateNotifications = () => {
-    if (totalPages === currentPage) {
+  const updateNotifications = async () => {
+    if (totalPages === currentPage || totalPages < currentPage) {
       setHasMore(false);
     }
 
-    fetchNotifications(currentPage)
-      .then(response => {
-        setNotifications(notifications.concat(response.body));
-        setTotalPages(response.page.totalPages);
-      })
-      .catch(error => {
-        //TODO Error handling
-      });
-
+    let response = await fetchNotifications(currentPage);
+    setNotifications(notifications.concat(response.body));
+    setTotalPages(response.page.totalPages);
     setCurrentPage(currentPage + 1);
   }
 
@@ -39,7 +33,7 @@ export default function NotificationPage() {
   return (
     <PageLayout>
       <Header>
-        <BackHeader Title={"알림"} />
+        <BackHeader Title={"알림"}/>
       </Header>
       <ShortHeaderPageContainer>
         {


### PR DESCRIPTION
중복으로 페이지가 렌더링 되거나, 페이지가 누락되는 오류 해결

> 추가로 알림 페이지에서 .then() 문법 대신 async await 키워드 적용