### PR TITLE
메인 공지사항 새 창 열림 + 처음 푸시알림 권한 요청 경험 개선

### DIFF
--- a/like-knu/.well-known/assetlinks.json
+++ b/like-knu/.well-known/assetlinks.json
@@ -1,0 +1,8 @@
+[{
+      "relation": ["delegate_permission/common.handle_all_urls"],
+      "target": {
+        "namespace": "android_app",
+        "package_name": "ac.knu.likeknu",
+        "sha256_cert_fingerprints": ["45:61:EA:2C:DE:C3:4D:8C:C3:87:45:37:4A:CE:77:5C:A3:D6:E4:2B:D5:A7:06:32:22:2B:1D:BF:0E:05:30:2C"]
+      }
+    }]

--- a/like-knu/.well-known/assetlinks.json
+++ b/like-knu/.well-known/assetlinks.json
@@ -1,8 +1,0 @@
-[{
-      "relation": ["delegate_permission/common.handle_all_urls"],
-      "target": {
-        "namespace": "android_app",
-        "package_name": "ac.knu.likeknu",
-        "sha256_cert_fingerprints": ["45:61:EA:2C:DE:C3:4D:8C:C3:87:45:37:4A:CE:77:5C:A3:D6:E4:2B:D5:A7:06:32:22:2B:1D:BF:0E:05:30:2C"]
-      }
-    }]

--- a/like-knu/public/.well-known/assetlinks.json
+++ b/like-knu/public/.well-known/assetlinks.json
@@ -3,6 +3,6 @@
       "target": {
         "namespace": "android_app",
         "package_name": "ac.knu.likeknu",
-        "sha256_cert_fingerprints": ["45:61:EA:2C:DE:C3:4D:8C:C3:87:45:37:4A:CE:77:5C:A3:D6:E4:2B:D5:A7:06:32:22:2B:1D:BF:0E:05:30:2C"]
+        "sha256_cert_fingerprints": ["E3:0C:9D:27:68:CE:E5:56:CE:95:5A:9A:CE:6E:51:38:AD:55:89:16:E5:BE:49:A2:1C:C0:37:07:F3:5E:AF:B2"]
       }
     }]

--- a/like-knu/src/components/main/MainNotice.jsx
+++ b/like-knu/src/components/main/MainNotice.jsx
@@ -26,10 +26,8 @@ export default function MainNotice({ selectCampus }) {
     <NoticeContainer>
       <Title onClick={goNotice}>{PAGE_NAME.NOTICE}</Title>
       {notices.map((notice) => (
-        <Text key={notice.announcementId}>
-          <a href={notice.announcementUrl} className="notice_link">
-            {notice.announcementTitle}
-          </a>
+        <Text key={notice.announcementId} onClick={() => window.open(notice.announcementUrl, "_blank")}>
+          {notice.announcementTitle}
         </Text>
       ))}
     </NoticeContainer>

--- a/like-knu/src/pages/SettingNotificationPage.jsx
+++ b/like-knu/src/pages/SettingNotificationPage.jsx
@@ -23,12 +23,12 @@ export default function SettingNotificationPage() {
   };
 
   const changeDeviceNotification = async () => {
-    changeTurnOnNotification(!isTurnOn);
-    if (!isTurnOn) {
+    setIsTurnOn(!isTurnOn);
+    changeTurnOnNotification(isTurnOn);
+    if (isTurnOn) {
       let token = await requestNotificationPermission();
       updateNotificationToken(token);
     }
-    setIsTurnOn(!isTurnOn);
   };
 
   useEffect(() => {

--- a/like-knu/src/pages/SettingNotificationPage.jsx
+++ b/like-knu/src/pages/SettingNotificationPage.jsx
@@ -24,8 +24,8 @@ export default function SettingNotificationPage() {
 
   const changeDeviceNotification = async () => {
     setIsTurnOn(!isTurnOn);
-    changeTurnOnNotification(isTurnOn);
-    if (isTurnOn) {
+    changeTurnOnNotification(!isTurnOn);
+    if (!isTurnOn) {
       let token = await requestNotificationPermission();
       updateNotificationToken(token);
     }


### PR DESCRIPTION
self에서 창이 열리면 아이폰의 경우 창이 깨지는 문제 발생. window.open으로 _blank 설정을 했습니다

기존에는 토글을 눌러 알림을 키면, 푸시알림 설정 +  API 요청이 끝나야 토글이 켜짐 상태로 바뀌었습니다. 그걸 누르자마자 토글 상태가 켜짐으로 바뀌고 푸시알림 권한 요청과 API 호출을 하도록 했습니다.